### PR TITLE
Remove ability to block oneself

### DIFF
--- a/acts_as_follower.gemspec
+++ b/acts_as_follower.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "shoulda"
+  s.add_development_dependency "shoulda", "~>2.11.3"
   s.add_development_dependency "factory_girl", "~>2.6.0"
   s.add_development_dependency "rails", "~>3.0.10"
 end

--- a/acts_as_follower.gemspec
+++ b/acts_as_follower.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "shoulda"
-  s.add_development_dependency "factory_girl"
+  s.add_development_dependency "factory_girl", "~>2.6.0"
   s.add_development_dependency "rails", "~>3.0.10"
 end

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -89,7 +89,7 @@ module ActsAsFollower #:nodoc:
       private
 
       def block_future_follow(follower)
-        follows.create(:followable => self, :follower => follower, :blocked => true)
+        follows.create(:followable => self, :follower => follower, :blocked => true) unless follower == self
       end
 
       def block_existing_follow(follower)

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -111,6 +111,16 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       end
     end
 
+    context "blocking yourself" do
+      setup do
+        @jon.block(@jon)
+      end
+
+      should "not add self to the blocked followers" do
+        assert_equal 0, @jon.blocked_followers_count
+      end
+    end
+
     context "blocking a follower" do
       context "in my following list" do
         setup do


### PR DESCRIPTION
Hi,

Great gem, saved me a lot of code! I've forked and made two bug fixes and one improvement suggestion. Please review, and feel free to pull one or more of them:

1. Latest factory_girl version is not compatible with ruby 1.8, so I locked the gem to a version that works with 1.8 and 1.9.

2. Latest shoulda has deprecated & removed should_change, which your tests use. Locked the gem to an older version that still has this method.

3. Since an object cannot follow oneself, it makes no sense to be able to block oneself. I removed the ability and added a test to verify a followable cannot block oneself.

Regards, Ryan