### PR TITLE
Upgrades for library compatibility

### DIFF
--- a/acts_as_follower.gemspec
+++ b/acts_as_follower.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "shoulda_create"
-  s.add_development_dependency "shoulda", "3.5.0"
-  s.add_development_dependency "factory_girl", "4.2.0"
+  s.add_development_dependency "shoulda", ">= 3.5.0"
+  s.add_development_dependency "factory_girl", ">= 4.2.0"
   s.add_development_dependency "rails", "~> 4.0.0"
 end

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -77,11 +77,17 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
 
     context "destroying a followable" do
       setup do
+        @follow_count = Follow.count
+        @sam_following_count = @sam.all_following.size
         @jon.destroy
       end
 
-      should_change("follow count", :by => -1) { Follow.count }
-      should_change("@sam.all_following.size", :by => -1) { @sam.all_following.size }
+      should "change counts" do
+        assert_equal Follow.count, (@follow_count - 1)
+        @sam.reload
+        assert_equal @sam.all_following.size, (@sam_following_count - 1)
+      end
+
     end
 
     context "get follow record" do

--- a/test/acts_as_follower_test.rb
+++ b/test/acts_as_follower_test.rb
@@ -40,11 +40,16 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
 
     context "follow a friend" do
       setup do
+        @original_follow_count = Follow.count
+        @jon_follow_count = @jon.follow_count
         @jon.follow(@sam)
       end
 
-      should_change("Follow count", :by => 1) { Follow.count }
-      should_change("@jon.follow_count", :by => 1) { @jon.follow_count }
+      should "change counts" do
+        assert_equal Follow.count, @original_follow_count + 1
+        @jon.reload
+        assert_equal @jon.follow_count, @jon_follow_count + 1
+      end
 
       should "set the follower" do
         assert_equal @jon, Follow.last.follower
@@ -57,11 +62,16 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
 
     context "follow yourself" do
       setup do
+        @follow_count = Follow.count
+        @jon_follow_count = @jon.follow_count
         @jon.follow(@jon)
       end
 
-      should_not_change("Follow count") { Follow.count }
-      should_not_change("@jon.follow_count") { @jon.follow_count }
+      should "not change counts" do
+        assert_equal Follow.count, @follow_count
+        @jon.reload
+        assert_equal @jon.follow_count, @jon_follow_count
+      end
 
       should "not set the follower" do
         assert_not_equal @jon, Follow.last.follower
@@ -74,11 +84,17 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
 
     context "stop_following" do
       setup do
+        @follow_count = Follow.count
+        @sam_follow_count = @sam.follow_count
         @sam.stop_following(@jon)
       end
 
-      should_change("Follow count", :by => -1) { Follow.count }
-      should_change("@sam.follow_count", :by => -1) { @sam.follow_count }
+      should "change counts" do
+        assert_equal Follow.count, (@follow_count - 1)
+        @sam.reload
+        assert_equal @sam.follow_count, (@sam_follow_count - 1)
+      end
+
     end
 
     context "follows" do
@@ -175,11 +191,16 @@ class ActsAsFollowerTest < ActiveSupport::TestCase
 
     context "destroying follower" do
       setup do
+        @follow_count = Follow.count
+        @sam_follow_count = @sam.follow_count
         @jon.destroy
       end
 
-      should_change("Follow.count", :by => -1) { Follow.count }
-      should_change("@sam.follow_count", :by => -1) { @sam.follow_count }
+      should "change counts" do
+        assert_equal Follow.count, (@follow_count - 1)
+        @sam.reload
+        assert_equal @sam.follow_count, (@sam_follow_count - 1)
+      end
     end
 
     context "blocked by followable" do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
 
   factory :sam, :class => User do |u|
     u.name 'Sam'
-   end
+  end
 
   factory :bob, :class => User do |u|
     u.name 'Bob'


### PR DESCRIPTION
This pull request includes a few changes:

i) Eliminating use of the now removed should_change macro in the tests
ii) Updating the use of FactoryGirl to use the new syntax rather than the older syntax that is not supported in the latest versions of the FactoryGirl gem
iii) Editing the gemspec to support Rails versions greater than 3.0.x
iv) Adding a .travis.yml file

It would be great if this could be pulled in and a new gem version released.  I'm looking to use this gem on a new Rails 3.2 project.

Please let me know if there's anything else I can do to make that happen.  Thanks.
