### PR TITLE
Fix sti bubbling

### DIFF
--- a/acts_as_follower.gemspec
+++ b/acts_as_follower.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "shoulda"
-  s.add_development_dependency "factory_girl"
+  s.add_development_dependency "shoulda", "~>2.0"
+  s.add_development_dependency "factory_girl", "~>2.0"
   s.add_development_dependency "rails", "~>3.0.10"
 end

--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -5,10 +5,11 @@ module ActsAsFollower
 
     # Retrieves the parent class name if using STI.
     def parent_class_name(obj)
-      if obj.class.superclass != ActiveRecord::Base
-        return obj.class.superclass.name
+      klass = obj.class
+      while klass.superclass != ActiveRecord::Base
+        klass = klass.superclass
       end
-      return obj.class.name
+      return klass.name
     end
 
   end

--- a/test/follower_lib_test.rb
+++ b/test/follower_lib_test.rb
@@ -1,0 +1,36 @@
+require File.dirname(__FILE__) + '/test_helper'
+
+class RockBand < Band; end
+class HardRockBand < RockBand; end
+
+class LibTestCase
+  include ActsAsFollower::FollowerLib
+end
+
+class FollowerLibTest < ActiveSupport::TestCase
+
+  context "parent_class_name" do
+
+    setup do
+      @obj = LibTestCase.new
+    end
+
+    context "Object inheriting from active record base" do
+      should "return the object's class name" do
+        assert_equal @obj.send(:parent_class_name, Band.new), Band.name
+      end
+    end
+
+    context "Single level STI class" do
+      should "return the parent classes name" do
+        assert_equal @obj.send(:parent_class_name, RockBand.new), Band.name
+      end
+    end
+
+    context "n Level STI Class" do
+      should "return the top level parent from STI" do
+        assert_equal @obj.send(:parent_class_name, HardRockBand.new), Band.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently the ActsAsFollower::FollowerLib#parent_class_name method only supports a single level of inheritance in STI.  We currently have a use case which results in at least a 3rd level of STI and need support to bubble up to the top level when following them. This pull request provides support for bubbling up n levels of STI.

For example:

``` ruby
class Band < ActiveRecord::Base
end

class RockBand < Band
end

class HardRockBand < RockBand
end
```
