### PR TITLE
Add nil check for followed_by?

### DIFF
--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -83,6 +83,7 @@ module ActsAsFollower #:nodoc:
       # Returns true if the current instance is followed by the passed record
       # Returns false if the current instance is blocked by the passed record or no follow is found
       def followed_by?(follower)
+        return false if follower.nil?
         self.followings.unblocked.for_follower(follower).first.present?
       end
 

--- a/lib/acts_as_follower/follower.rb
+++ b/lib/acts_as_follower/follower.rb
@@ -40,6 +40,15 @@ module ActsAsFollower #:nodoc:
         end
       end
 
+      # Calls `follow` if not following, call `stop_following` if following
+      def toggle_follow(followable)
+        if following? followable
+          stop_following followable
+        else
+          follow followable
+        end
+      end
+
       # returns the follows records to the current instance
       def follows_scoped
         self.follows.unblocked.includes(:followable)

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -72,6 +72,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       should "return_follower_status" do
         assert_equal true, @jon.followed_by?(@sam)
         assert_equal false, @sam.followed_by?(@jon)
+        assert_equal false, @sam.followed_by?(nil)
       end
     end
 


### PR DESCRIPTION
This commit makes `followed_by? nil` returns false. This change is useful for visitors(current_user returns nil) on website. When visitors visits a user page, those visitors are not following the user.