### PR TITLE
Uses first_or_create in Follower#follow

### DIFF
--- a/lib/acts_as_follower/follower.rb
+++ b/lib/acts_as_follower/follower.rb
@@ -29,7 +29,8 @@ module ActsAsFollower #:nodoc:
       # Does not allow duplicate records to be created.
       def follow(followable)
         if self != followable
-          self.follows.find_or_create_by(followable_id: followable.id, followable_type: parent_class_name(followable))
+          params = {followable_id: followable.id, followable_type: parent_class_name(followable)}
+          self.follows.where(params).first_or_create!
         end
       end
 


### PR DESCRIPTION
Uses first_or_create! instead of deprecated find_or_create. Old way
causes #follow to fail in certain Rails versions

first_or_create is available since Rails 3.2, find_or_create is
deprecated in Rails 4.0