### PR TITLE
Fix blocking

### DIFF
--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -89,7 +89,7 @@ module ActsAsFollower #:nodoc:
       private
 
       def block_future_follow(follower)
-        follows.create(:followable => self, :follower => follower, :blocked => true)
+        Follow.create(:followable => self, :follower => follower, :blocked => true)
       end
 
       def block_existing_follow(follower)


### PR DESCRIPTION
In an app I'm working on (using rails 3.2.19, acts_as_follower 0.1.1) there is an issue with blocking: method `block` creates a following record where both follower and followable are the same records (one that should be only referenced as followable). This small patch fixes the issue.