### PR TITLE
Use new Ruby 1.9 hash syntax instead of old syntax

### DIFF
--- a/lib/acts_as_follower/follow_scopes.rb
+++ b/lib/acts_as_follower/follow_scopes.rb
@@ -2,20 +2,20 @@ module ActsAsFollower #:nodoc:
   module FollowScopes
 
     def for_follower(follower)
-      where(:follower_id => follower.id,
-            :follower_type => parent_class_name(follower))
+      where(follower_id: follower.id,
+            follower_type: parent_class_name(follower))
     end
 
     def for_followable(followable)
-      where(:followable_id => followable.id, :followable_type => parent_class_name(followable))
+      where(followable_id: followable.id, followable_type: parent_class_name(followable))
     end
 
     def for_follower_type(follower_type)
-      where(:follower_type => follower_type)
+      where(follower_type: follower_type)
     end
 
     def for_followable_type(followable_type)
-      where(:followable_type => followable_type)
+      where(followable_type: followable_type)
     end
 
     def recent(from)
@@ -27,11 +27,11 @@ module ActsAsFollower #:nodoc:
     end
 
     def unblocked
-      where(:blocked => false)
+      where(blocked: false)
     end
 
     def blocked
-      where(:blocked => true)
+      where(blocked: true)
     end
 
   end

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -7,7 +7,7 @@ module ActsAsFollower #:nodoc:
 
     module ClassMethods
       def acts_as_followable
-        has_many :followings, :as => :followable, :dependent => :destroy, :class_name => 'Follow'
+        has_many :followings, as: :followable, dependent: :destroy, class_name: 'Follow'
         include ActsAsFollower::Followable::InstanceMethods
         include ActsAsFollower::FollowerLib
       end
@@ -24,10 +24,10 @@ module ActsAsFollower #:nodoc:
       def followers_by_type(follower_type, options={})
         follows = follower_type.constantize.
           joins(:follows).
-          where('follows.blocked'         => false,
-                'follows.followable_id'   => self.id,
-                'follows.followable_type' => parent_class_name(self),
-                'follows.follower_type'   => follower_type)
+          where('follows.blocked' =>          false,
+                'follows.followable_id' =>    self.id,
+                'follows.followable_type' =>  parent_class_name(self),
+                'follows.follower_type' =>    follower_type)
         if options.has_key?(:limit)
           follows = follows.limit(options[:limit])
         end
@@ -101,7 +101,7 @@ module ActsAsFollower #:nodoc:
       private
 
       def block_future_follow(follower)
-        Follow.create(:followable => self, :follower => follower, :blocked => true)
+        Follow.create(followable: self, follower: follower, blocked: true)
       end
 
       def block_existing_follow(follower)

--- a/lib/acts_as_follower/follower.rb
+++ b/lib/acts_as_follower/follower.rb
@@ -7,7 +7,7 @@ module ActsAsFollower #:nodoc:
 
     module ClassMethods
       def acts_as_follower
-        has_many :follows, :as => :follower, :dependent => :destroy
+        has_many :follows, as: :follower, dependent: :destroy
         include ActsAsFollower::Follower::InstanceMethods
         include ActsAsFollower::FollowerLib
       end
@@ -66,10 +66,10 @@ module ActsAsFollower #:nodoc:
       def following_by_type(followable_type, options={})
         followables = followable_type.constantize.
           joins(:followings).
-          where('follows.blocked'         => false,
-                'follows.follower_id'     => self.id,
-                'follows.follower_type'   => parent_class_name(self),
-                'follows.followable_type' => followable_type)
+          where('follows.blocked' =>          false,
+                'follows.follower_id' =>      self.id,
+                'follows.follower_type' =>    parent_class_name(self),
+                'follows.followable_type' =>  followable_type)
         if options.has_key?(:limit)
           followables = followables.limit(options[:limit])
         end

--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,14 +1,14 @@
 class ActsAsFollowerMigration < ActiveRecord::Migration
   def self.up
-    create_table :follows, :force => true do |t|
-      t.references :followable, :polymorphic => true, :null => false
-      t.references :follower,   :polymorphic => true, :null => false
-      t.boolean :blocked, :default => false, :null => false
+    create_table :follows, force: true do |t|
+      t.references :followable, polymorphic: true, null: false
+      t.references :follower,   polymorphic: true, null: false
+      t.boolean :blocked,       default: false,    null: false
       t.timestamps
     end
 
-    add_index :follows, ["follower_id", "follower_type"],     :name => "fk_follows"
-    add_index :follows, ["followable_id", "followable_type"], :name => "fk_followables"
+    add_index :follows, ["follower_id", "follower_type"],     name: "fk_follows"
+    add_index :follows, ["followable_id", "followable_type"], name: "fk_followables"
   end
 
   def self.down

--- a/lib/generators/templates/model.rb
+++ b/lib/generators/templates/model.rb
@@ -4,8 +4,8 @@ class Follow < ActiveRecord::Base
   extend ActsAsFollower::FollowScopes
 
   # NOTE: Follows belong to the "followable" interface, and also to followers
-  belongs_to :followable, :polymorphic => true
-  belongs_to :follower,   :polymorphic => true
+  belongs_to :followable, polymorphic: true
+  belongs_to :follower,   polymorphic: true
 
   def block!
     self.update_attribute(:blocked, true)


### PR DESCRIPTION
I have changed the old hash syntax to new Ruby 1.9 hash syntax.