### PR TITLE
Rails5 fix follower method

### DIFF
--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -5,10 +5,11 @@ module ActsAsFollower
 
     # Retrieves the parent class name if using STI.
     def parent_class_name(obj)
-      if obj.class.superclass != ActiveRecord::Base
-        return obj.class.superclass.name
+      if obj.class.superclass == ActiveRecord::Base ||
+        obj.class.superclass.superclass == ActiveRecord::Base 
+        return obj.class.name
       end
-      return obj.class.name
+      return obj.class.superclass.name
     end
 
     def apply_options_to_scope(scope, options = {})


### PR DESCRIPTION
Fix parent_class_name for rails5.
This is rails5.0.0.beta1 output.
```
>> user.class.name
=> "User"
>> user.class.superclass.name
=> "ApplicationRecord"
>> user.class.superclass.superclass.name
=> "ActiveRecord::Base"
```