### PR TITLE
change blocks => blocked_followers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -174,9 +174,9 @@ To unblock is just as simple
   book.unblock(user)
 
 To get all blocked records
-  book.blocks # Returns an array of blocked follower records (only unblocked) (eg. type User or type Book)
+  book.blocked_followers # Returns an array of blocked follower records (only unblocked) (eg. type User or type Book)
 
-If you only need the number of blocks use the count method provided
+If you only need the number of blocked_followers use the count method provided
   book.blocked_followers_count
 
 Unblocking deletes all records of that follow, instead of just the :blocked attribute => false the follow is deleted.  So, a user would need to try and follow the book again.

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -74,7 +74,7 @@ module ActsAsFollower #:nodoc:
         followers_scope.to_a.collect{|f| f.follower}
       end
 
-      def blocks(options={})
+      def blocked_followers(options={})
         blocked_followers_scope = followers_scoped.blocked
         blocked_followers_scope = apply_options_to_scope(blocked_followers_scope, options)
         blocked_followers_scope.to_a.collect{|f| f.follower}

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -99,7 +99,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       end
     end
 
-    context "blocks" do
+    context "blocked_followers" do
       setup do
         @bob = FactoryGirl.create(:bob)
         @jon.block(@sam)
@@ -107,7 +107,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       end
 
       should "accept AR options" do
-        assert_equal 1, @jon.blocks(limit: 1).count
+        assert_equal 1, @jon.blocked_followers(limit: 1).count
       end
     end
 
@@ -134,8 +134,8 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
           assert_equal [], @jon.followers
         end
 
-        should "be in the list of blocks" do
-          assert_equal [@sam], @jon.blocks
+        should "be in the list of blocked_followers" do
+          assert_equal [@sam], @jon.blocked_followers
         end
       end
 
@@ -157,8 +157,8 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
           assert_equal [], @sam.followers
         end
 
-        should "be in the list of blocks" do
-          assert_equal [@jon], @sam.blocks
+        should "be in the list of blocked_followers" do
+          assert_equal [@jon], @sam.blocked_followers
         end
       end
     end
@@ -175,7 +175,7 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
 
       should "remove him from the blocked followers" do
         assert_equal 0, @jon.blocked_followers_count
-        assert_equal [], @jon.blocks
+        assert_equal [], @jon.blocked_followers
       end
     end
 
@@ -193,8 +193,8 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
         assert_equal 0, @jon.blocked_followers_count
       end
 
-      should "not be in the blocks list" do
-        assert_equal [], @jon.blocks
+      should "not be in the blocked_followers list" do
+        assert_equal [], @jon.blocked_followers
       end
     end
 


### PR DESCRIPTION
I have a model called `Block` which was conflicting with the `blocks` method. 

I thought the method name `blocked_followers` is better suited and less confusing than `blocks`. 