### PR TITLE
remove deprecated custom_parent code

### DIFF
--- a/lib/acts_as_follower.rb
+++ b/lib/acts_as_follower.rb
@@ -6,28 +6,5 @@ module ActsAsFollower
   autoload :FollowerLib,  'acts_as_follower/follower_lib'
   autoload :FollowScopes, 'acts_as_follower/follow_scopes'
 
-  def self.setup
-    @configuration ||= Configuration.new
-    yield @configuration if block_given?
-  end
-
-  def self.method_missing(method_name, *args, &block)
-    if method_name == :custom_parent_classes=
-      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
-    end
-    @configuration.respond_to?(method_name) ?
-        @configuration.send(method_name, *args, &block) : super
-  end
-
-  class Configuration
-    attr_accessor :custom_parent_classes
-
-    def initialize
-      @custom_parent_classes = []
-    end
-  end
-
-  setup
-
   require 'acts_as_follower/railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
 end

--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -3,14 +3,9 @@ module ActsAsFollower
 
     private
 
-    DEFAULT_PARENTS = [ApplicationRecord, ActiveRecord::Base]
-
     # Retrieves the parent class name if using STI.
     def parent_class_name(obj)
-      unless parent_classes.include?(obj.class.superclass)
-        return obj.class.base_class.name
-      end
-      obj.class.name
+      obj.class.base_class.name
     end
 
     def apply_options_to_scope(scope, options = {})
@@ -32,11 +27,5 @@ module ActsAsFollower
       scope
     end
 
-    def parent_classes
-      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes
-
-      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
-      ActsAsFollower.custom_parent_classes + DEFAULT_PARENTS
-    end
   end
 end

--- a/test/factories/somes.rb
+++ b/test/factories/somes.rb
@@ -1,9 +1,0 @@
-FactoryGirl.define do
-  factory :daddy, :class => Some do |b|
-    b.name 'Daddy'
-  end
-
-  factory :mommy, :class => Some do |b|
-    b.name 'Mommy'
-  end
-end

--- a/test/follow_test.rb
+++ b/test/follow_test.rb
@@ -7,22 +7,4 @@ class FollowTest < ActiveSupport::TestCase
     assert true
   end
 
-  context "configuration with setters" do
-    should "contain custom parents" do
-      ActsAsFollower.custom_parent_classes = [CustomRecord]
-
-      assert_equal [CustomRecord], ActsAsFollower.custom_parent_classes
-    end
-  end
-
-  context "#setup" do
-    should "contain custom parents via setup" do
-      ActsAsFollower.setup do |c|
-        c.custom_parent_classes = [CustomRecord]
-      end
-
-      assert_equal [CustomRecord], ActsAsFollower.custom_parent_classes
-    end
-  end
-
 end


### PR DESCRIPTION
This removes the custom parent class code recently deprecated in #56.

I figure we don’t need to merge this right away, because #56 was _just_ merged to `master`, but I wanted to make the PR while it was all still fresh in my mind. Nothing urgent, but we can merge whenever the timing makes sense.

Tests remain green, and this should not affect behavior (other than removing custom parent classes).