### PR TITLE
Don’t warn about deprecations in Test env;

### DIFF
--- a/lib/acts_as_follower.rb
+++ b/lib/acts_as_follower.rb
@@ -13,7 +13,7 @@ module ActsAsFollower
 
   def self.method_missing(method_name, *args, &block)
     if method_name == :custom_parent_classes=
-      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
+      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.") unless Rails.env.test?
     end
     @configuration.respond_to?(method_name) ?
         @configuration.send(method_name, *args, &block) : super

--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -35,7 +35,7 @@ module ActsAsFollower
     def parent_classes
       return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes
 
-      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
+      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.") unless Rails.env.test?
       ActsAsFollower.custom_parent_classes + DEFAULT_PARENTS
     end
   end


### PR DESCRIPTION
Deprecation warning is skipped if `Rails.env.test?`.