### PR TITLE
no deprecation warning if custom_parent_classes==[]

### DIFF
--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -33,7 +33,7 @@ module ActsAsFollower
     end
 
     def parent_classes
-      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes
+      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes.present?
 
       ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
       ActsAsFollower.custom_parent_classes + DEFAULT_PARENTS


### PR DESCRIPTION
As mentioned in https://github.com/tcocca/acts_as_follower/pull/89#issuecomment-288847274 and in some of the issues like https://github.com/tcocca/acts_as_follower/issues/91, the current `master` version is issuing unnecessary deprecation warnings when `custom_parent_classes == []`.

Merging #89 will make this PR moot, because that refactors away the `custom_parent_classes` object entirely. That would be my personal recommendation.

But, if there is hesitation to merge #89 for whatever reason, then we can at least merge this in the meantime and remove some of those unnecessary warnings. We could then aim to merge #89 at some later point in time.