### PR TITLE
Add rails version to migration file

### DIFF
--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,4 +1,4 @@
-class ActsAsFollowerMigration < ActiveRecord::Migration
+class ActsAsFollowerMigration < ActiveRecord::Migration[Rails::VERSION::STRING[0..2].to_f]
   def self.up
     create_table :follows, force: true do |t|
       t.references :followable, polymorphic: true, null: false


### PR DESCRIPTION
Migrations versioning is required  from Rails 5.
Rails 5+ requires the rails version specified and throws an error during migration if not specified.
Compatible with previous Rails versions. ie:  ActiveRecord::Migration[4.2] is still valid