### PR TITLE
Add plucks functionality for followers of an object

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -181,6 +181,14 @@ The following methods take an optional hash parameter of ActiveRecord options (:
   followers_by_type, followers, blocks
 ---
 
+To simulate the Activerecord `pluck` method for followers
+  book.pluck_followers(:name)
+
+This method, like the original `pluck` method, will also take multiple column names as parameters
+  book.pluck_followers(:name, :email)
+
+Note that this method will be applied to all followers, regardless of scope.
+
 === Follow Model
 
 The Follow model has a set of named_scope's.  In case you want to interface directly with the Follow model you can use them.

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -98,6 +98,12 @@ module ActsAsFollower #:nodoc:
         self.followings.for_follower(follower).first
       end
 
+      def pluck_followers(*columns)
+        follower_ids = self.followings.pluck(:follower_id)
+        follower_ids.collect {|f| User.where(id: f).pluck(*columns)}.flatten(1)
+      end
+
+
       private
 
       def block_future_follow(follower)

--- a/lib/acts_as_follower/followable.rb
+++ b/lib/acts_as_follower/followable.rb
@@ -100,7 +100,7 @@ module ActsAsFollower #:nodoc:
 
       def pluck_followers(*columns)
         follower_ids = self.followings.pluck(:follower_id)
-        follower_ids.collect {|f| User.where(id: f).pluck(*columns)}.flatten(1)
+        follower_ids.flat_map { |f| User.where(id: f).pluck(*columns)}
       end
 
 

--- a/test/acts_as_followable_test.rb
+++ b/test/acts_as_followable_test.rb
@@ -279,5 +279,26 @@ class ActsAsFollowableTest < ActiveSupport::TestCase
       end
     end
 
+    context "returns follower info via pluck" do
+      setup do
+        @addy = FactoryGirl.create(:addy)
+        @claire = FactoryGirl.create(:claire)
+        @oasis = FactoryGirl.create(:oasis)
+        @addy.follow(@oasis)
+        @claire.follow(@oasis)
+      end
+
+      should "return values when plucking single attribute of followers" do
+        expected_value = ["addy@example.com", "claire@example.com"]
+        assert_equal expected_value, @oasis.pluck_followers(:email)
+      end
+
+      should "return values when plucking multiple attributes of followers" do
+        expected_value = [["Addison", "addy@example.com"],
+                          ["Claire", "claire@example.com"]]
+        assert_equal expected_value, @oasis.pluck_followers(:name, :email)
+      end
+    end
+
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -10,4 +10,14 @@ FactoryGirl.define do
   factory :bob, class: User do |u|
     u.name 'Bob'
   end
+
+  factory :addy, class: User do |u|
+  	u.name 'Addison'
+  	u.email 'addy@example.com'
+  end
+
+  factory :claire, class: User do |u|
+  	u.name 'Claire'
+  	u.email 'claire@example.com'
+  end
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,4 +1,4 @@
-ActiveRecord::Schema.define version: 0 do
+ActiveRecord::Schema.define version: 1 do
 
   create_table :follows, force: true do |t|
     t.integer  "followable_id",   null: false
@@ -12,6 +12,7 @@ ActiveRecord::Schema.define version: 0 do
 
   create_table :users, force: true do |t|
     t.column :name, :string
+    t.column :email, :string
   end
 
   create_table :bands, force: true do |t|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,5 @@ require 'shoulda_create'
 require 'factory_girl'
 ActiveSupport::TestCase.extend(ShouldaCreate)
 FactoryGirl.find_definitions
+
+Minitest::Reporters.use!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,5 +16,3 @@ require 'shoulda_create'
 require 'factory_girl'
 ActiveSupport::TestCase.extend(ShouldaCreate)
 FactoryGirl.find_definitions
-
-Minitest::Reporters.use!


### PR DESCRIPTION
Adds functionality simulating the Activerecord method `pluck`.  Like `pluck`, the method can accept multiple column names.  

The method currently returns data for all followers of the object, regardless of the scope.  Trying to allow options on scoping causes a problem with eager loading as this is a polymorphic association.  I chose to abandon that route as I did not want to change a fundamental feature of the gem as it is now.  If anyone knows of a way to allow options on scoping without running into eager loading efforts, please let me know of add your own commits to this branch.