### PR TITLE
Remove deprecated Gem::Specification#rubyforge_project

### DIFF
--- a/acts_as_follower.gemspec
+++ b/acts_as_follower.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{acts_as_follower is a Rubygem to allow any model to follow any other model. This is accomplished through a double polymorphic relationship on the Follow model. There is also built in support for blocking/un-blocking follow records. Main uses would be for Users to follow other Users or for Users to follow Books, etc… (Basically, to develop the type of follow system that GitHub has)}
   s.license     = 'MIT'
 
-  s.rubyforge_project = "acts_as_follower"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -33,7 +33,7 @@ module ActsAsFollower
     end
 
     def parent_classes
-      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes
+      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes.present?
 
       ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
       ActsAsFollower.custom_parent_classes + DEFAULT_PARENTS


### PR DESCRIPTION
https://github.com/rubygems/rubygems/pull/2798

```sh
$ bundle update
Fetching https://github.com/tcocca/acts_as_follower.git
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from acts_as_follower.gemspec:15.
```