### PR TITLE
[NVMD-808] Fixing deprecation warning

### DIFF
--- a/lib/acts_as_follower.rb
+++ b/lib/acts_as_follower.rb
@@ -11,9 +11,15 @@ module ActsAsFollower
     yield @configuration if block_given?
   end
 
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new('next-version', 'acts_as_follower')
+  end
+
   def self.method_missing(method_name, *args, &block)
     if method_name == :custom_parent_classes=
-      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
+      deprecator.warn(
+        "Setting custom parent classes is deprecated and will be removed in future versions."
+      )
     end
     @configuration.respond_to?(method_name) ?
         @configuration.send(method_name, *args, &block) : super

--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -35,7 +35,9 @@ module ActsAsFollower
     def parent_classes
       return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes
 
-      ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
+      ActsAsFollower.deprecator.warn(
+        "Setting custom parent classes is deprecated and will be removed in future versions."
+      )
       ActsAsFollower.custom_parent_classes + DEFAULT_PARENTS
     end
   end


### PR DESCRIPTION
Rails 7 deprecated the way the deprecation warning works. This PR uses the new method.